### PR TITLE
feat(azure): add configuration for Azure OpenAI Service

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const openai = new OpenAIApi(
     azure: {
       apiKey: <key1>
       endpoint: <endpoint>,
-    // deploymentName is optional, if you donot set it, you need to set it in the request parameter
+    // The `deploymentName` parameter is optional; if you do not set it, you need to put it in the request parameter
       deploymentName: <model-deployment-name>,
       apiVerison: '2023-03-15-preview' // or other version
     }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library allows you to use Azure OpenAI's API without making any changes to 
 ## Installation
 
 ```bash
-$ npm install @unique/openai
+$ npm install @unique-ag/openai
 ```
 
 ## Usage
@@ -18,7 +18,7 @@ $ npm install @unique/openai
 The library must be configured with your Azure OpenAI's `key`, `endpoint`, and `deploymentId`. You can obtain these credentials from [Azure Portal](https://portal.azure.com).
 
 ```ts
-import { Configuration, OpenAIApi } from '@unique/openai';
+import { Configuration, OpenAIApi } from '@unique-ag/openai';
 
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,

--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ const response = await this.openAiApi.createCompletion({
   bestOf: 1,
 });
 ```
+
+## Releases
+
+This library follows the versioning and releases of the official OpenAI node library.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install @unique/openai
 
 ## Usage
 
-The library needs to be configured with your Azure OpenAI's key, endpoint and deploymentId. you can obtain these credentials from [Azure Portal](https://portal.azure.com).
+The library must be configured with your Azure OpenAI's `key`, `endpoint`, and `deploymentId`. You can obtain these credentials from [Azure Portal](https://portal.azure.com).
 
 ```ts
 import { Configuration, OpenAIApi } from '@unique/openai';

--- a/README.md
+++ b/README.md
@@ -1,89 +1,70 @@
-# OpenAI Node.js Library
+# Azure OpenAI NodeJS Library
 
-The OpenAI Node.js library provides convenient access to the OpenAI API from Node.js applications. Most of the code in this library is generated from our [OpenAPI specification](https://github.com/openai/openai-openapi).
+This is a fork of the official [OpenAI Node.js library](https://github.com/openai/openai-node) that has been adapted to support the Azure OpenAI API. The objective of this library is to minimize the changes required to migrate from the official OpenAI library to Azure OpenAI or revert back to OpenAI.
 
-**Important note: this library is meant for server-side usage only, as using it in client-side browser code will expose your secret API key. [See here](https://platform.openai.com/docs/api-reference/authentication) for more details.**
+> **Note**
+> It is also an inofficial fork of [1openwindow/azure-openai-node](https://github.com/1openwindow/azure-openai-node) which we could not use due to due diligence reasons 🥇 
+
+This library allows you to use Azure OpenAI's API without making any changes to your existing OpenAI code. You can simply add Azure information to your configuration and start using the Azure OpenAI model.
 
 ## Installation
 
 ```bash
-npm install openai
+$ npm install @unique/openai
 ```
 
 ## Usage
 
-The library needs to be configured with your account's secret key, which is available on the [website](https://platform.openai.com/account/api-keys). We recommend setting it as an environment variable. Here's an example of initializing the library with the API key loaded from an environment variable and creating a completion:
+The library needs to be configured with your Azure OpenAI's key, endpoint and deploymentId. you can obtain these credentials from [Azure Portal](https://portal.azure.com).
 
-```javascript
-const { Configuration, OpenAIApi } = require("openai");
+```ts
+import { Configuration, OpenAIApi } from '@unique/openai';
 
 const configuration = new Configuration({
   apiKey: process.env.OPENAI_API_KEY,
 });
-const openai = new OpenAIApi(configuration);
+
+const openai = new OpenAIApi(
+  new Configuration({
+    apiKey: this.apiKey,
+    // add azure info into configuration
+    azure: {
+      apiKey: <key1>
+      endpoint: <endpoint>,
+    // deploymentName is optional, if you donot set it, you need to set it in the request parameter
+      deploymentName: <model-deployment-name>,
+      apiVerison: '2023-03-15-preview' // or other version
+    }
+  )
+);
 
 const completion = await openai.createCompletion({
   model: "text-davinci-003",
   prompt: "Hello world",
 });
+
 console.log(completion.data.choices[0].text);
+
 ```
 
-Check out the [full API documentation](https://platform.openai.com/docs/api-reference?lang=node.js) for examples of all the available functions.
-
-### Request options
-
-All of the available API request functions additionally contain an optional final parameter where you can pass custom [axios request options](https://axios-http.com/docs/req_config), for example:
-
-```javascript
-const completion = await openai.createCompletion(
-  {
-    model: "text-davinci-003",
-    prompt: "Hello world",
-  },
-  {
-    timeout: 1000,
-    headers: {
-      "Example-Header": "example",
-    },
-  }
-);
+## Variations
+### Streaming
+Azure OpenAI does not response delta data, so you need to change the response to text
+```ts
+// before: const delta = parsed.choices[0].delta.content;
+const delta = parsed.choices[0].text;
 ```
 
-### Error handling
-
-API requests can potentially return errors due to invalid inputs or other issues. These errors can be handled with a `try...catch` statement, and the error details can be found in either `error.response` or `error.message`:
-
-```javascript
-try {
-  const completion = await openai.createCompletion({
-    model: "text-davinci-003",
-    prompt: "Hello world",
-  });
-  console.log(completion.data.choices[0].text);
-} catch (error) {
-  if (error.response) {
-    console.log(error.response.status);
-    console.log(error.response.data);
-  } else {
-    console.log(error.message);
-  }
-}
+### Deployment name
+```ts
+const response = await this.openAiApi.createCompletion({
+  model: <deployement>,
+  prompt: prompt,
+  maxTokens: 100,
+  temperature: 0.9,
+  topP: 1,
+  presencePenalty: 0,
+  frequencyPenalty: 0,
+  bestOf: 1,
+});
 ```
-
-### Streaming completions
-
-Streaming completions (`stream=true`) are not natively supported in this package yet, but [a workaround exists](https://github.com/openai/openai-node/issues/18#issuecomment-1369996933) if needed.
-
-## Upgrade guide
-
-All breaking changes for major version releases are listed below.
-
-### 3.0.0
-
-- The function signature of `createCompletion(engineId, params)` changed to `createCompletion(params)`. The value previously passed in as the `engineId` argument should now be passed in as `model` in the params object (e.g. `createCompletion({ model: "text-davinci-003", ... })`)
-- Replace any `createCompletionFromModel(params)` calls with `createCompletion(params)`
-
-## Thanks
-
-Thank you to [ceifa](https://github.com/ceifa) for creating and maintaining the original unofficial `openai` npm package before we released this official library! ceifa's original package has been renamed to [gpt-x](https://www.npmjs.com/package/gpt-x).

--- a/api.ts
+++ b/api.ts
@@ -15,7 +15,6 @@
 import type { Configuration } from './configuration';
 import type { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
-
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
@@ -2097,12 +2096,14 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
         createEmbedding: async (createEmbeddingRequest: CreateEmbeddingRequest, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'createEmbeddingRequest' is not null or undefined
             assertParamExists('createEmbedding', 'createEmbeddingRequest', createEmbeddingRequest)
+
             let localVarPath = `/embeddings`;
             if (configuration.azure) {
-                const deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createEmbeddingRequest.model;
-                const apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
-                localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=${configuration.azure.apiVersion}`;
+                const deploymentName = configuration.azure.deploymentName ?? createEmbeddingRequest.model;
+                const apiVersion = configuration.azure.apiVersion ?? '2023-03-15-preview';
+                localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=${apiVersion}`;
             }
+            
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/api.ts
+++ b/api.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Configuration } from './configuration';
-import type { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
+import type { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
 
 // Some imports not used depending on template conditions

--- a/api.ts
+++ b/api.ts
@@ -12,16 +12,16 @@
  * Do not edit the class manually.
  */
 
-
+import type { Configuration } from './configuration';
 import type { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
-import type { Configuration } from './configuration';
+
 // Some imports not used depending on template conditions
 // @ts-ignore
+import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 import type { RequestArgs } from './base';
-import { DUMMY_BASE_URL, assertParamExists, createRequestFunction, serializeDataIfNeeded, setSearchParams, toPathString } from './common';
 // @ts-ignore
-import { BASE_PATH, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError } from './base';
 
 /**
  * 
@@ -287,12 +287,6 @@ export interface CreateChatCompletionRequest {
      * @memberof CreateChatCompletionRequest
      */
     'messages'?: Array<ChatCompletionRequestMessage>;
-    /**
-     * The messages to generate chat completions for, in the [chat format](/docs/guides/chat/introduction).
-     * @type {Array<ChatCompletionRequestMessage>}
-     * @memberof CreateChatCompletionRequest
-     */
-    'prompt'?: string;
     /**
      * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.  We generally recommend altering this or `top_p` but not both. 
      * @type {number}
@@ -1947,9 +1941,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
 
             let localVarPath = `/chat/completions`;
             if (configuration.azure) {
-                const deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createChatCompletionRequest.model;
-                const apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
-                localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=${configuration.azure.apiVersion}`;
+                const deploymentName = configuration.azure.deploymentName ?? createChatCompletionRequest.model;
+                const apiVersion = configuration.azure.apiVersion ?? '2023-03-15-preview';
+                localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=${apiVersion}`;
             }
 
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -2026,9 +2020,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             assertParamExists('createCompletion', 'createCompletionRequest', createCompletionRequest)
             let localVarPath = `/completions`;
             if (configuration.azure) {
-                let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createCompletionRequest.model;
-                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
-                localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=${configuration.azure.apiVersion}`;
+                const deploymentName = configuration.azure.deploymentName ?? createCompletionRequest.model;
+                const apiVersion = configuration.azure.apiVersion ?? '2023-03-15-preview';
+                localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=${apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);

--- a/api.ts
+++ b/api.ts
@@ -13,15 +13,15 @@
  */
 
 
-import type { Configuration } from './configuration';
-import type { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
+import type { Configuration } from './configuration';
 // Some imports not used depending on template conditions
 // @ts-ignore
-import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
 import type { RequestArgs } from './base';
+import { DUMMY_BASE_URL, assertParamExists, createRequestFunction, serializeDataIfNeeded, setSearchParams, toPathString } from './common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError } from './base';
+import { BASE_PATH, BaseAPI, RequiredError } from './base';
 
 /**
  * 
@@ -286,7 +286,13 @@ export interface CreateChatCompletionRequest {
      * @type {Array<ChatCompletionRequestMessage>}
      * @memberof CreateChatCompletionRequest
      */
-    'messages': Array<ChatCompletionRequestMessage>;
+    'messages'?: Array<ChatCompletionRequestMessage>;
+    /**
+     * The messages to generate chat completions for, in the [chat format](/docs/guides/chat/introduction).
+     * @type {Array<ChatCompletionRequestMessage>}
+     * @memberof CreateChatCompletionRequest
+     */
+    'prompt'?: string;
     /**
      * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.  We generally recommend altering this or `top_p` but not both. 
      * @type {number}
@@ -1938,7 +1944,13 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
         createChatCompletion: async (createChatCompletionRequest: CreateChatCompletionRequest, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'createChatCompletionRequest' is not null or undefined
             assertParamExists('createChatCompletion', 'createChatCompletionRequest', createChatCompletionRequest)
-            const localVarPath = `/chat/completions`;
+
+            let localVarPath = `/chat/completions`;
+            if (configuration.azure) {
+                let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createChatCompletionRequest.model;
+                localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=2023-03-15-preview`; // FIXME make version variable Konsti and Dominik
+            }
+
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -2011,7 +2023,11 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
         createCompletion: async (createCompletionRequest: CreateCompletionRequest, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'createCompletionRequest' is not null or undefined
             assertParamExists('createCompletion', 'createCompletionRequest', createCompletionRequest)
-            const localVarPath = `/completions`;
+            let localVarPath = `/completions`;
+            if (configuration.azure) {
+                let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createCompletionRequest.model;
+                localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=2023-03-15-preview`; // FIXME dynamic version konsti and dominik
+            }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -2083,7 +2099,11 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
         createEmbedding: async (createEmbeddingRequest: CreateEmbeddingRequest, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'createEmbeddingRequest' is not null or undefined
             assertParamExists('createEmbedding', 'createEmbeddingRequest', createEmbeddingRequest)
-            const localVarPath = `/embeddings`;
+            let localVarPath = `/embeddings`;
+            if (configuration.azure) {
+                let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createEmbeddingRequest.model;
+                localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=2023-03-15-preview`; // fixme, dynamic version konsti and dominik
+            }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/api.ts
+++ b/api.ts
@@ -1948,7 +1948,8 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             let localVarPath = `/chat/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createChatCompletionRequest.model;
-                localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=2023-03-15-preview`; // FIXME make version variable Konsti and Dominik
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
+                localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=${configuration.azure.apiVersion}`;
             }
 
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -2026,7 +2027,8 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             let localVarPath = `/completions`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createCompletionRequest.model;
-                localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=2023-03-15-preview`; // FIXME dynamic version konsti and dominik
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
+                localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=${configuration.azure.apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -2102,7 +2104,8 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             let localVarPath = `/embeddings`;
             if (configuration.azure) {
                 let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createEmbeddingRequest.model;
-                localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=2023-03-15-preview`; // fixme, dynamic version konsti and dominik
+                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
+                localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=${configuration.azure.apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);

--- a/api.ts
+++ b/api.ts
@@ -2103,8 +2103,8 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             assertParamExists('createEmbedding', 'createEmbeddingRequest', createEmbeddingRequest)
             let localVarPath = `/embeddings`;
             if (configuration.azure) {
-                let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createEmbeddingRequest.model;
-                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
+                const deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createEmbeddingRequest.model;
+                const apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
                 localVarPath = `/openai/deployments/${deploymentName}/embeddings?api-version=${configuration.azure.apiVersion}`;
             }
             // use dummy base URL string because the URL constructor only accepts absolute URLs.

--- a/api.ts
+++ b/api.ts
@@ -1947,8 +1947,8 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
 
             let localVarPath = `/chat/completions`;
             if (configuration.azure) {
-                let deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createChatCompletionRequest.model;
-                let apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
+                const deploymentName = configuration.azure.deploymentName ? configuration.azure.deploymentName : createChatCompletionRequest.model;
+                const apiVersion = configuration.azure.apiVersion ? configuration.azure.apiVersion : '2023-03-15-preview';
                 localVarPath = `/openai/deployments/${deploymentName}/chat/completions?api-version=${configuration.azure.apiVersion}`;
             }
 

--- a/api.ts
+++ b/api.ts
@@ -286,7 +286,7 @@ export interface CreateChatCompletionRequest {
      * @type {Array<ChatCompletionRequestMessage>}
      * @memberof CreateChatCompletionRequest
      */
-    'messages'?: Array<ChatCompletionRequestMessage>;
+    'messages': Array<ChatCompletionRequestMessage>;
     /**
      * What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.  We generally recommend altering this or `top_p` but not both. 
      * @type {number}
@@ -2018,12 +2018,14 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
         createCompletion: async (createCompletionRequest: CreateCompletionRequest, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'createCompletionRequest' is not null or undefined
             assertParamExists('createCompletion', 'createCompletionRequest', createCompletionRequest)
+            
             let localVarPath = `/completions`;
             if (configuration.azure) {
                 const deploymentName = configuration.azure.deploymentName ?? createCompletionRequest.model;
                 const apiVersion = configuration.azure.apiVersion ?? '2023-03-15-preview';
                 localVarPath = `/openai/deployments/${deploymentName}/completions?api-version=${apiVersion}`;
             }
+            
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/common.ts
+++ b/common.ts
@@ -12,6 +12,7 @@
  * Do not edit the class manually.
  */
 
+
 import type { Configuration } from "./configuration";
 import type { RequestArgs } from "./base";
 import type { AxiosInstance, AxiosResponse } from 'axios';

--- a/common.ts
+++ b/common.ts
@@ -13,10 +13,11 @@
  */
 
 
-import type { Configuration } from "./configuration";
-import type { RequestArgs } from "./base";
 import type { AxiosInstance, AxiosResponse } from 'axios';
+import { ChatCompletionRequestMessage } from "./api";
+import type { RequestArgs } from "./base";
 import { RequiredError } from "./base";
+import type { Configuration } from "./configuration";
 
 /**
  *
@@ -147,4 +148,30 @@ export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxi
         const axiosRequestArgs = {...axiosArgs.options, url: (configuration?.basePath || basePath) + axiosArgs.url};
         return axios.request<T, R>(axiosRequestArgs);
     };
+}
+
+/**
+ * 
+ * @export
+ */
+export const createPrompt = function (systemMessage: string, messages: { sender: string, text: string }[]): string {
+    let prompt = systemMessage;
+    for (const message of messages) {
+        prompt += `\n<|im_start|>${message.sender}\n${message.text}\n<|im_end|>`;
+    }
+    prompt += "\n<|im_start|>assistant\n";
+    return prompt;
+}
+
+export const messageToAzurePrompt = function (messages: Array<ChatCompletionRequestMessage>): string {
+    let systemMessage = '';
+    let conversationMessage = [];
+    for (const message of messages) {
+        systemMessage = message.role === "system" ? `<|im_start|>system\n{'${message.content}'}\n<|im_end|>` : '';
+        conversationMessage.push({
+            sender: message.role,
+            text: message.content,
+        })
+    }
+    return createPrompt(systemMessage, conversationMessage);
 }

--- a/common.ts
+++ b/common.ts
@@ -12,12 +12,10 @@
  * Do not edit the class manually.
  */
 
-
-import type { AxiosInstance, AxiosResponse } from 'axios';
-import { ChatCompletionRequestMessage } from "./api";
-import type { RequestArgs } from "./base";
-import { RequiredError } from "./base";
 import type { Configuration } from "./configuration";
+import type { RequestArgs } from "./base";
+import type { AxiosInstance, AxiosResponse } from 'axios';
+import { RequiredError } from "./base";
 
 /**
  *
@@ -148,30 +146,4 @@ export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxi
         const axiosRequestArgs = {...axiosArgs.options, url: (configuration?.basePath || basePath) + axiosArgs.url};
         return axios.request<T, R>(axiosRequestArgs);
     };
-}
-
-/**
- * 
- * @export
- */
-export const createPrompt = function (systemMessage: string, messages: { sender: string, text: string }[]): string {
-    let prompt = systemMessage;
-    for (const message of messages) {
-        prompt += `\n<|im_start|>${message.sender}\n${message.text}\n<|im_end|>`;
-    }
-    prompt += "\n<|im_start|>assistant\n";
-    return prompt;
-}
-
-export const messageToAzurePrompt = function (messages: Array<ChatCompletionRequestMessage>): string {
-    let systemMessage = '';
-    let conversationMessage = [];
-    for (const message of messages) {
-        systemMessage = message.role === "system" ? `<|im_start|>system\n{'${message.content}'}\n<|im_end|>` : '';
-        conversationMessage.push({
-            sender: message.role,
-            text: message.content,
-        })
-    }
-    return createPrompt(systemMessage, conversationMessage);
 }

--- a/configuration.ts
+++ b/configuration.ts
@@ -16,8 +16,8 @@
 const packageJson = require("../package.json");
 
 export interface AzureConfigurationParameters {
-    apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
-    endpoint?: string;
+    apiKey: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
+    endpoint: string;
     deploymentName?: string;
     apiVersion?: string; // fixme use this later
 }
@@ -122,8 +122,8 @@ export class Configuration {
             this.formDataCtor = require("form-data");
         }
         if (this.azure) {
-            if (!this.azure.apiKey || !this.azure.endpoint || !this.azure.deploymentName || !this.azure.apiVersion) {
-                throw new Error("Azure Configuration requires apiKey, endpoint, deploymentName, and apiVersion");
+            if (!this.azure.apiKey || !this.azure.endpoint) {
+                throw new Error("Azure Configuration requires apiKey and endpoint.");
             }
             this.apiKey = this.azure.apiKey;
             this.baseOptions.headers['api-key'] = this.azure.apiKey;

--- a/configuration.ts
+++ b/configuration.ts
@@ -15,6 +15,13 @@
 
 const packageJson = require("../package.json");
 
+export interface AzureConfigurationParameters {
+    apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
+    endpoint?: string;
+    deploymentName?: string;
+    apiVersion?: string; // fixme use this later
+}
+
 export interface ConfigurationParameters {
     apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
     organization?: string;
@@ -24,6 +31,7 @@ export interface ConfigurationParameters {
     basePath?: string;
     baseOptions?: any;
     formDataCtor?: new () => any;
+    azure?: AzureConfigurationParameters;
 }
 
 export class Configuration {
@@ -83,6 +91,10 @@ export class Configuration {
      * @type {new () => FormData}
      */
     formDataCtor?: new () => any;
+    /**
+     * @memberof Configuration
+     */
+    azure?: AzureConfigurationParameters;
 
     constructor(param: ConfigurationParameters = {}) {
         this.apiKey = param.apiKey;
@@ -93,12 +105,13 @@ export class Configuration {
         this.basePath = param.basePath;
         this.baseOptions = param.baseOptions;
         this.formDataCtor = param.formDataCtor;
+        this.azure = param.azure;
 
         if (!this.baseOptions) {
             this.baseOptions = {};
         }
         this.baseOptions.headers = {
-            'User-Agent': `OpenAI/NodeJS/${packageJson.version}`,
+            'User-Agent': `AzureQOpenAI/NodeJS/${packageJson.version}`,
             'Authorization': `Bearer ${this.apiKey}`,
             ...this.baseOptions.headers,
         }
@@ -107,6 +120,15 @@ export class Configuration {
         }
         if (!this.formDataCtor) {
             this.formDataCtor = require("form-data");
+        }
+        if (this.azure) {
+            if (!this.azure.apiKey || !this.azure.endpoint || !this.azure.deploymentName || !this.azure.apiVersion) {
+                throw new Error("Azure Configuration requires apiKey, endpoint, deploymentName, and apiVersion");
+            }
+            this.apiKey = this.azure.apiKey;
+            this.baseOptions.headers['api-key'] = this.azure.apiKey;
+            this.baseOptions.headers['Authorization'] = '';
+            this.basePath = this.azure.endpoint;
         }
     }
 

--- a/configuration.ts
+++ b/configuration.ts
@@ -111,7 +111,7 @@ export class Configuration {
             this.baseOptions = {};
         }
         this.baseOptions.headers = {
-            'User-Agent': `AzureQOpenAI/NodeJS/${packageJson.version}`,
+            'User-Agent': `AzureOpenAI/NodeJS/${packageJson.version}`,
             'Authorization': `Bearer ${this.apiKey}`,
             ...this.baseOptions.headers,
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "openai",
+  "name": "@unique-ag/openai",
   "version": "3.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "openai",
+      "name": "@unique-ag/openai",
       "version": "3.2.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "openai",
-  "version": "0.9.0",
+  "name": "@unique-ag/openai",
+  "version": "3.2.1",
   "description": "Node.js library for the Azure OpenAI API, forked from the official node package.",
   "repository": {
     "type": "git",
@@ -15,6 +15,14 @@
     "gpt3"
   ],
   "author": "Unique AG",
+  "contributors": [
+    {
+      "name": "OpenAI"
+    },
+    {
+      "name": "Unique AG"
+    }
+  ],
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,20 @@
 {
   "name": "openai",
-  "version": "3.2.1",
-  "description": "Node.js library for the OpenAI API",
+  "version": "0.9.0",
+  "description": "Node.js library for the Azure OpenAI API, forked from the official node package.",
   "repository": {
     "type": "git",
-    "url": "git@github.com:openai/openai-node.git"
+    "url": "git@github.com:unique-ag/openai-node.git"
   },
   "keywords": [
+    "azure-openai",
     "openai",
     "open",
     "ai",
     "gpt-3",
     "gpt3"
   ],
-  "author": "OpenAI",
+  "author": "Unique AG",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Add an `azure` configuration option to support Azure OpenAI API calls in addition to the original OpenAI API calls.

To keep the diff clean, the commit does not involve a compiled version of the package in the `/dist` folder.

Reviewed-by: @konsti 
Refs: https://github.com/1openwindow/azure-openai-node